### PR TITLE
Fix TypeScript errors in gap down scanner

### DIFF
--- a/server/src/handlers/stockAnalysis.ts
+++ b/server/src/handlers/stockAnalysis.ts
@@ -127,6 +127,7 @@ interface GapUpStock {
 	companyName?: string;
 	exchange?: string;
 	first15MinHigh?: string;
+	first15MinLow?: string;
 	first15MinClose?: string;
 }
 


### PR DESCRIPTION
- Add first15MinLow field to GapUpStock interface
- Implement proper gap down trading logic (first 15min low < 20-day low)
- Add market hours validation for intraday charts
- Return user-friendly error messages for weekend/after-hours chart requests

🤖 Generated with [Claude Code](https://claude.ai/code)